### PR TITLE
Remove tab space at end of manifest file. Causes push to fail

### DIFF
--- a/MsSQL-Binding-Sample/SoftballStatsViewer/manifest.yml
+++ b/MsSQL-Binding-Sample/SoftballStatsViewer/manifest.yml
@@ -6,5 +6,3 @@ applications:
   stack: windows2012
   services:
   - free-sql
-
-	


### PR DESCRIPTION
Push fails with "found a tab character that violate intendation at line 10, column 1". Tab space is removed.
